### PR TITLE
Updated gitignore to ignore all .iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/.DS_Store
 .idea/
 target/
-Nameless-Link.iml
+*.iml
 .classpath
 .settings/
 .project


### PR DESCRIPTION
IntelliJ names the project differently. For me, it used bot.iml as name as that is defined in the pom.xml