### PR TITLE
Updated update_usernames command to use user tag instead of displayname.

### DIFF
--- a/src/main/java/com/namelessmc/bot/commands/ConfigureCommand.java
+++ b/src/main/java/com/namelessmc/bot/commands/ConfigureCommand.java
@@ -273,7 +273,7 @@ public class ConfigureCommand extends Command {
             for (int i = 0; i < members.size(); i++) {
                 final User user = members.get(i).getUser();
                 discordIds[i] = user.getIdLong();
-                discordUsernames[i] = user.getAsTag();
+                discordUsernames[i] = user.getName();
             }
             try {
                 api.discord().updateDiscordUsernames(discordIds, discordUsernames);

--- a/src/main/java/com/namelessmc/bot/commands/ConfigureCommand.java
+++ b/src/main/java/com/namelessmc/bot/commands/ConfigureCommand.java
@@ -273,7 +273,7 @@ public class ConfigureCommand extends Command {
             for (int i = 0; i < members.size(); i++) {
                 final User user = members.get(i).getUser();
                 discordIds[i] = user.getIdLong();
-                discordUsernames[i] = user.getGlobalName();
+                discordUsernames[i] = user.getAsTag();
             }
             try {
                 api.discord().updateDiscordUsernames(discordIds, discordUsernames);


### PR DESCRIPTION
The website upon linking with discord account sets the "username" in database to the user's discord tag, while the update_usernames command, when ran, updates it to the user's discord display name.

This commit makes it so the update_usernames command also updates the "username" field in database to the user's discord tag, and not the display name.